### PR TITLE
Add post-install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,60 @@
 # UserAuth Microservice
 
-This project lists runtime and development dependencies for a Fastify-based authentication service.
+Fastify-based authentication service.
+
+## Available Scripts
+
+```jsonc
+{
+  "type": "module",
+  "scripts": {
+    "dev": "tsx watch src/main.ts",
+    "build": "esbuild src/main.ts --bundle --platform=node --target=node20 --outfile=dist/main.js",
+    "start": "node dist/main.js",
+    "migrate": "prisma migrate dev --name init",
+    "generate": "prisma generate",
+    "test": "vitest",
+    "prepare": "husky install"
+  }
+}
+```
+
+- `type: module` lets you use native ESM imports.
+- `dev` uses tsx for super-fast reloads.
+- `build` bundles into a single file with esbuild.
+
+## Post-install Steps
+
+### Prisma
+```bash
+npx prisma init            # creates prisma/schema.prisma & .env
+npm run migrate            # runs first migration & seeds DB
+```
+
+### Husky + lint-staged
+```bash
+npm run prepare
+npx husky add .husky/pre-commit "npx lint-staged"
+```
+
+Add to `package.json`:
+```jsonc
+"lint-staged": {
+  "*.ts": ["eslint --fix", "prettier --write"]
+}
+```
+
+## Development
+
+Start the dev server:
+```bash
+npm run dev
+```
+
+Run tests:
+```bash
+npm test
+```
 
 ## Runtime Dependencies
 
@@ -65,4 +119,3 @@ This project lists runtime and development dependencies for a Fastify-based auth
   }
 }
 ```
-

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "microservice built for authentication. ",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "dev": "tsx watch src/main.ts",
     "build": "esbuild src/main.ts --bundle --platform=node --target=node20 --outfile=dist/main.js",
@@ -58,5 +59,8 @@
     "tsx": "^4.20.3",
     "typescript": "^5.8.3",
     "vitest": "^3.2.4"
+  },
+  "lint-staged": {
+    "*.ts": ["eslint --fix", "prettier --write"]
   }
 }


### PR DESCRIPTION
## Summary
- reorganize README and add sections for scripts and post-install steps
- document husky/lint-staged config
- enable ESM in package.json and add lint-staged settings

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e21a68fe0832ca1d1bd5a708fecd4